### PR TITLE
add block timestamp cache to indexers

### DIFF
--- a/lib/eth/src/key_registry.rs
+++ b/lib/eth/src/key_registry.rs
@@ -132,6 +132,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         store: &Store,
         log: &Log,
         chain_id: u32,
+        timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let fid = U256::from_big_endian(log.topics[1].as_bytes()).as_u64();
         let key_type = U256::from_big_endian(log.topics[2].as_bytes()).as_u32();
@@ -166,7 +167,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
             chain_id,
             block_number: log.block_number.unwrap().as_u32(),
             block_hash: log.block_hash.unwrap().to_fixed_bytes().to_vec(),
-            block_timestamp: 0,
+            block_timestamp: timestamp as u64,
             transaction_hash: log.transaction_hash.unwrap().as_bytes().to_vec(),
             log_index: log.log_index.unwrap().as_u32(),
             fid,
@@ -225,6 +226,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         store: &Store,
         log: &Log,
         chain_id: u32,
+        timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let fid = U256::from_big_endian(log.topics[1].as_bytes());
         let key_hash = Address::from(log.topics[2]);
@@ -256,7 +258,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
             chain_id,
             block_number: log.block_number.unwrap().as_u32(),
             block_hash: log.block_hash.unwrap().to_fixed_bytes().to_vec(),
-            block_timestamp: 0,
+            block_timestamp: timestamp as u64,
             transaction_hash: log.transaction_hash.unwrap().as_bytes().to_vec(),
             log_index: log.log_index.unwrap().as_u32(),
             fid: fid.as_u64(),
@@ -298,6 +300,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         store: &Store,
         log: &Log,
         chain_id: u32,
+        timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let fid = U256::from_big_endian(log.topics[1].as_bytes());
         let key_hash = Address::from(log.topics[2]);
@@ -327,7 +330,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
             chain_id,
             block_number: log.block_number.unwrap().as_u32(),
             block_hash: log.block_hash.unwrap().to_fixed_bytes().to_vec(),
-            block_timestamp: 0,
+            block_timestamp: timestamp as u64,
             transaction_hash: log.transaction_hash.unwrap().as_bytes().to_vec(),
             log_index: log.log_index.unwrap().as_u32(),
             fid: fid.as_u64(),
@@ -366,6 +369,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         store: &Store,
         log: &Log,
         chain_id: u32,
+        timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let parsed_log: Migrated = parse_log(log.clone()).unwrap();
         let body = SignerMigratedEventBody {
@@ -379,7 +383,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
             chain_id,
             block_number: log.block_number.unwrap().as_u32(),
             block_hash: log.block_hash.unwrap().to_fixed_bytes().to_vec(),
-            block_timestamp: 0,
+            block_timestamp: timestamp as u64,
             transaction_hash: log.transaction_hash.unwrap().as_bytes().to_vec(),
             log_index: log.log_index.unwrap().as_u32(),
             fid: 0,

--- a/lib/eth/src/storage_registry.rs
+++ b/lib/eth/src/storage_registry.rs
@@ -80,6 +80,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         store: &Store,
         log: &Log,
         chain_id: u32,
+        timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let parsed_log: Rent = parse_log(log.clone()).unwrap();
         let units = parsed_log.units.as_u32();
@@ -98,7 +99,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
             chain_id,
             block_number: log.block_number.unwrap().as_u32(),
             block_hash: log.block_hash.unwrap().to_fixed_bytes().to_vec(),
-            block_timestamp: 0,
+            block_timestamp: timestamp as u64,
             transaction_hash: log.transaction_hash.unwrap().as_bytes().to_vec(),
             log_index: log.log_index.unwrap().as_u32(),
             fid,
@@ -140,6 +141,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         _store: &Store,
         log: &Log,
         _chain_id: u32,
+        _timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let parsed_log: SetMaxUnits = parse_log(log.clone()).unwrap();
         let _old_max = parsed_log.oldMax.as_u32();
@@ -172,6 +174,7 @@ impl<T: JsonRpcClient + Clone> Contract<T> {
         _store: &Store,
         log: &Log,
         _chain_id: u32,
+        _timestamp: i64,
     ) -> Result<(), Box<dyn Error>> {
         let parsed_log: SetDeprecationTimestamp = parse_log(log.clone()).unwrap();
         let _old_timestamp = parsed_log.oldTimestamp.as_u32();

--- a/lib/hub/src/main.rs
+++ b/lib/hub/src/main.rs
@@ -70,7 +70,7 @@ async fn main() {
 
     let provider = Provider::<Http>::try_from(config.optimism_l2_rpc_url).unwrap();
 
-    let indexer = Indexer::new(
+    let mut indexer = Indexer::new(
         store.clone(),
         provider,
         config.chain_id,


### PR DESCRIPTION
Adds a block timestamp map to the indexer to cache timestamp values for block hashes

When we fetch events over 2000 blocks at a time for syncing the various contracts, this will help avoid making useless RPC calls by doing it once per block hash

