### PR TITLE
fix(logger): initialize after loading .env

### DIFF
--- a/lib/hub/src/main.rs
+++ b/lib/hub/src/main.rs
@@ -48,10 +48,10 @@ struct Config {
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
-
     // Load env vars from .env file
     dotenv().ok();
+
+    env_logger::init();
 
     // Load configuration from a TOML file and override with environment variables
     let config: Config = Figment::new()


### PR DESCRIPTION
Initialize the logger after the .env is read to include the RUST_LOG variable in the logger's initialization.