### PR TITLE
Read bootstrap nodes from config

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -8,3 +8,4 @@ key_registry_address = "0x00000000Fc1237824fb747aBDE0FF18990E59b7e"
 storage_registry_address = "0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d"
 abi_dir = "./lib/eth/abis"
 indexer_interval = 60                                                   # This value is in seconds
+bootstrap_addrs = ["/ip4/107.21.22.118/tcp/2282"]

--- a/lib/hub/src/main.rs
+++ b/lib/hub/src/main.rs
@@ -44,6 +44,7 @@ struct Config {
     storage_registry_address: String,
     abi_dir: String,
     indexer_interval: u64,
+    bootstrap_addrs: Vec<String>,
 }
 
 #[tokio::main]
@@ -103,12 +104,11 @@ async fn main() {
 
     log::info!("Public Key: {}", hex::encode(pub_key.to_bytes()));
 
-    let bootstrap_nodes = vec![
-        // Multiaddr::from_str("/ip4/3.17.4.160/tcp/2282").unwrap(),
-        Multiaddr::from_str("/ip4/23.20.92.219/tcp/2282").unwrap(),
-        // Multiaddr::from_str("/ip4/3.223.235.209/tcp/2282").unwrap(),
-        // Multiaddr::from_str("/ip4/52.20.72.19/tcp/2282").unwrap(),
-    ];
+    let bootstrap_nodes = config
+        .bootstrap_addrs
+        .iter()
+        .map(|addr| Multiaddr::from_str(addr).unwrap())
+        .collect();
 
     let id_keypair = libp2p::identity::Keypair::ed25519_from_bytes(&mut secret_key_bytes).unwrap();
 


### PR DESCRIPTION
Reads the bootstrap node multiaddrs from the config instead of hardcoding it.